### PR TITLE
Updated CI to use GitHub Container Registry instead of Dockerhub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - "*"
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   test:
@@ -36,6 +36,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs: test
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -44,21 +47,21 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
-      - name: Login to docker hub
-        uses: actions-hub/docker/login@master
-        env:
-          DOCKER_USERNAME: terrycain
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build :latest
-        run: |
-          docker build -t terrycain/keyvault2kube:latest .
-          docker tag terrycain/keyvault2kube:latest terrycain/keyvault2kube:${{ steps.get_version.outputs.version }}
-      - name: Push to docker hub :latest
-        uses: actions-hub/docker@master
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Auth with GHCR
+        uses: docker/login-action@v1
         with:
-          args: push terrycain/keyvault2kube:latest
-
-      - name: Push to docker hub :${{ steps.get_version.outputs.version }}
-        uses: actions-hub/docker@master
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push Container
+        uses: docker/build-push-action@v2
         with:
-          args: push terrycain/keyvault2kube:${{ steps.get_version.outputs.version }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/terrycain/keyvault2kube:${{ steps.get_version.outputs.version }}
+            ghcr.io/terrycain/keyvault2kube:latest


### PR DESCRIPTION
# Changes

* Use GitHub Container Registry instead of Dockerhub
* Add arm64 builds, untested, but should work
* Limit builds to tags that match a valid semver